### PR TITLE
feat: add open_on_left config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 
 ---
 
-
 ## ✨ Features
 
 - **Fast and responsive** file tree using `fd`
@@ -62,6 +61,21 @@ require("Otree").setup({
     show_hidden = false,
     show_ignore = false,
     cursorline = true,
+	open_on_left = true,
+	oil = "float",
+
+	ignore_patterns = {},
+
+	keymaps = {
+		["<CR>"] = "actions.select",
+		["l"] = "actions.select",
+		["h"] = "actions.close_dir",
+		["q"] = "actions.close_win",
+		["<C-h>"] = "actions.goto_parent",
+		["<C-l>"] = "actions.goto_dir",
+		["<M-h>"] = "actions.goto_home_dir",
+		["cd"] = "actions.change_home_dir",
+		["L"] = "actions.open_dirs",
     oil = "float",
 
     ignore_patterns = {},

--- a/lua/Otree/init.lua
+++ b/lua/Otree/init.lua
@@ -10,6 +10,7 @@ local default_config = {
 	show_hidden = false,
 	show_ignore = false,
 	cursorline = true,
+	open_on_left = true,
 	oil = "float",
 
 	ignore_patterns = {},

--- a/lua/Otree/ui.lua
+++ b/lua/Otree/ui.lua
@@ -149,7 +149,8 @@ function M.create_buffer()
 end
 
 function M.create_window()
-	vim.cmd("topleft " .. tostring(state.win_size) .. "vsplit")
+	local position_cmd = state.left_size and "topleft" or "botright"
+	vim.cmd(position_cmd .. " " .. tostring(state.win_size) .. "vsplit")
 	state.win = vim.api.nvim_get_current_win()
 	vim.api.nvim_win_set_buf(state.win, state.buf)
 


### PR DESCRIPTION
Thank you for this great plugin!

The PR adds a new configuration option:
open_on_left — controls whether the file tree window appears on the left (true, default) or right (false) side of the editor.

Changes included:

- Added the open_on_left field to the default config in init.lua.
-  Updated create_window() in ui.lua to support this option.
-  Documented the option in README.md.

I’m happy to make adjustments or improvements based on feedback!