### PR TITLE
fix: add symlinks to the fd command

### DIFF
--- a/lua/Otree/fs.lua
+++ b/lua/Otree/fs.lua
@@ -82,7 +82,7 @@ end
 
 function M.scan_dir(dir)
 	dir = dir or vim.fn.getcwd()
-	local cmd = { state.fd, "--max-depth", "1", "--absolute-path", "-t", "f", "-t", "d" }
+	local cmd = { state.fd, "--max-depth", "1", "--absolute-path", "-t", "f", "-t", "d", "-t", "l" }
 	if state.show_hidden then
 		table.insert(cmd, "--hidden")
 	end


### PR DESCRIPTION
This brings Otree in line with oil.nvim and other filesystem viewers.

Closes #7 